### PR TITLE
Allow floats to be specified as the angle value in XML

### DIFF
--- a/diagonallayout/src/main/java/com/github/florent37/diagonallayout/DiagonalLayoutSettings.java
+++ b/diagonallayout/src/main/java/com/github/florent37/diagonallayout/DiagonalLayoutSettings.java
@@ -39,7 +39,7 @@ public class DiagonalLayoutSettings {
     DiagonalLayoutSettings(Context context, AttributeSet attrs) {
         TypedArray styledAttributes = context.obtainStyledAttributes(attrs, R.styleable.DiagonalLayout, 0, 0);
         try {
-            angle = styledAttributes.getInt(R.styleable.DiagonalLayout_diagonal_angle, 0);
+            angle = styledAttributes.getFloat(R.styleable.DiagonalLayout_diagonal_angle, 0);
             position = styledAttributes.getInt(R.styleable.DiagonalLayout_diagonal_position, BOTTOM);
             handleMargins = styledAttributes.getBoolean(R.styleable.DiagonalLayout_diagonal_handleMargins, false);
             direction = styledAttributes.getInt(R.styleable.DiagonalLayout_diagonal_direction, DIRECTION_LEFT);

--- a/diagonallayout/src/main/res/values/attrs.xml
+++ b/diagonallayout/src/main/res/values/attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="DiagonalLayout">
-        <attr name="diagonal_angle" format="integer" />
+        <attr name="diagonal_angle" format="float" />
         <attr name="diagonal_handleMargins" format="boolean"/>
         <attr name="diagonal_position" format="enum">
             <enum name="left" value="1" />


### PR DESCRIPTION
Allow floats to be specified as the angle value in XML to match DiagonalLayout.setAngle()